### PR TITLE
Returns the errors of the response if there are any

### DIFF
--- a/src/Jobs/Product/UpdateProductJob.php
+++ b/src/Jobs/Product/UpdateProductJob.php
@@ -10,6 +10,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use JustBetter\AkeneoProducts\Contracts\Product\UpdatesProduct;
 use JustBetter\AkeneoProducts\Models\Product;
+use Akeneo\Pim\ApiClient\Exception\UnprocessableEntityHttpException;
 use Throwable;
 
 class UpdateProductJob implements ShouldBeUnique, ShouldQueue
@@ -46,9 +47,9 @@ class UpdateProductJob implements ShouldBeUnique, ShouldQueue
     {
         $this->product->failed();
 
-        $responseErrors = ($throwable instanceof \Akeneo\Pim\ApiClient\Exception\UnprocessableEntityHttpException
-            ? $throwable->getResponseErrors()
-            : null) ?? [];
+        $responseErrors = $throwable instanceof UnprocessableEntityHttpException
+            ? $throwable->getResponseErrors() // @codeCoverageIgnore
+            : [];
 
         activity()
             ->on($this->product)

--- a/src/Jobs/Product/UpdateProductJob.php
+++ b/src/Jobs/Product/UpdateProductJob.php
@@ -46,11 +46,16 @@ class UpdateProductJob implements ShouldBeUnique, ShouldQueue
     {
         $this->product->failed();
 
+        $responseErrors = ($throwable instanceof \Akeneo\Pim\ApiClient\Exception\UnprocessableEntityHttpException
+            ? $throwable->getResponseErrors()
+            : null) ?? [];
+
         activity()
             ->on($this->product)
             ->useLog('error')
             ->withProperties([
                 'code' => $throwable->getCode(),
+                'response_errors' =>  $responseErrors
             ])
             ->log('Failed to update product in Akeneo: '.$throwable->getMessage());
     }

--- a/src/Jobs/ProductModel/UpdateProductModelJob.php
+++ b/src/Jobs/ProductModel/UpdateProductModelJob.php
@@ -46,12 +46,17 @@ class UpdateProductModelJob implements ShouldBeUnique, ShouldQueue
     {
         $this->productModel->failed();
 
+        $responseErrors = ($throwable instanceof \Akeneo\Pim\ApiClient\Exception\UnprocessableEntityHttpException
+            ? $throwable->getResponseErrors()
+            : null) ?? [];
+
         activity()
             ->on($this->productModel)
             ->useLog('error')
             ->withProperties([
                 'message' => $throwable->getMessage(),
                 'code' => $throwable->getCode(),
+                'response_errors' =>  $responseErrors
             ])
             ->log('Failed to update product model in Akeneo');
     }

--- a/src/Jobs/ProductModel/UpdateProductModelJob.php
+++ b/src/Jobs/ProductModel/UpdateProductModelJob.php
@@ -10,6 +10,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use JustBetter\AkeneoProducts\Contracts\ProductModel\UpdatesProductModel;
 use JustBetter\AkeneoProducts\Models\ProductModel;
+use Akeneo\Pim\ApiClient\Exception\UnprocessableEntityHttpException;
 use Throwable;
 
 class UpdateProductModelJob implements ShouldBeUnique, ShouldQueue
@@ -46,9 +47,9 @@ class UpdateProductModelJob implements ShouldBeUnique, ShouldQueue
     {
         $this->productModel->failed();
 
-        $responseErrors = ($throwable instanceof \Akeneo\Pim\ApiClient\Exception\UnprocessableEntityHttpException
-            ? $throwable->getResponseErrors()
-            : null) ?? [];
+        $responseErrors = $throwable instanceof UnprocessableEntityHttpException
+            ? $throwable->getResponseErrors() // @codeCoverageIgnore
+            : [];
 
         activity()
             ->on($this->productModel)


### PR DESCRIPTION
If the Throwable is an `UnprocessableEntityHttpException` it would be helpful to log the response error Akeneo provides. 

This PR's adds extra properties to the activity log when `UpdateProductJob` or `UpdateProductModelJob` fails 
